### PR TITLE
Add docker to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ In this repo we share useful resources and materials among echospace members.
 - [Code of Conduct](https://github.com/uw-echospace/group-docs/blob/main/coc.md)
 - [Onboarding Guide](https://github.com/uw-echospace/group_docs/blob/main/Onboarding.md)
 - [Getting started with Jupyter, conda, Python (relevant scientific packages) and Git/GitHub](conda_jupyterlab.md)
+- [Getting started with Docker](docker.md)


### PR DESCRIPTION
## Overview

This PR adds a link to the Getting started with Docker markdown file.